### PR TITLE
rbf-file as a parameter to init functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ NAME = libdbaserh.so.$(MAJOR).$(MINOR)
 # Compiler options
 CC = gcc
 CFLAGS = -g -Wall -O2 -DPACK_PATH=\"$(PACKAGE_PATH)\"
-LDLIBS = -l$(LIBUSBNAME) libdbaserh.a
+LDLIBS = libdbaserh.a -l$(LIBUSBNAME)
 LDFLAGS = -L.
 BINDIR = .
 VPATH = src
@@ -75,7 +75,7 @@ libdbaserh.o: $(SRC)      # build static lib part 1
 libdbaserhi.o: $(iSRC)    # build static lib part 2
 
 $(NAME): libdbaserhs.o libdbaserhis.o   # link shared
-	$(CC) -shared -fPIC -o $@ libdbaserhs.o libdbaserhis.o
+	$(CC) -shared -fPIC -o $@ libdbaserhs.o libdbaserhis.o -l$(LIBUSBNAME)
 
 libdbaserhs.o: $(SRC)     # build shared lib
 	$(CC) $(CFLAGS) -c -fPIC $< -o $@

--- a/src/dbaserh.c
+++ b/src/dbaserh.c
@@ -465,11 +465,23 @@ int main(int argc, char **argv) {
     dbase_exit(0);
   }
 
+  /* Get filename:
+     defined though gcc compiler option (-DPACK_PATH ...)
+     in Makefile
+  */
+#ifndef PACK_PATH
+    /* if no path is given, assume firmware in . */
+    char str[] = "digiBaseRH.rbf"; /*JK*/
+#else
+    char str[strlen(PACK_PATH) + 32];
+    snprintf(str, sizeof(str), "%s/digiBaseRH.rbf", PACK_PATH); /*JK*/
+#endif
+
   /* Find and open connection to detector */
   if(dev > 0){
     if(!q)
       printf("Opening device no %d (serial %d)\n", dev, serials[dev]);
-    det = libdbase_init(serials[dev]);
+    det = libdbase_init(serials[dev], str);
     if(det == NULL){
       if(!q)
 	fprintf(stderr, "Error: Couldn't open device no %d\n", dev);
@@ -479,7 +491,7 @@ int main(int argc, char **argv) {
   else{
     if(!q)
       printf("Opening first device\n");
-    if((det = libdbase_init(-1)) == NULL){
+    if((det = libdbase_init(-1, str)) == NULL){
       if(!q)
 	fprintf(stderr, "Error: Couldn't open digibase\n");
       return EXIT_FAILURE;

--- a/src/libdbaserh.h
+++ b/src/libdbaserh.h
@@ -317,7 +317,7 @@ int libdbase_set_pha_mode(detector *det);
     number of dbases in *found
 */
 
-int libdbase_get_list(detector *** list, int *found);
+int libdbase_get_list(detector *** list, int *found, const char *filename);
 
 /* 
    Close connection to each detector and free list 
@@ -333,7 +333,7 @@ int libdbase_free_list(detector *** list);
      otherwise a pointer to the dbase with the given serial
      number is returned
 */
-detector *libdbase_init(int dbase_serial);
+detector *libdbase_init(int dbase_serial, const char *filename);
 
 /*
   Close (usb) and release resources 

--- a/src/libdbaserhi.c
+++ b/src/libdbaserhi.c
@@ -546,7 +546,7 @@ void dbase_print_file_spectrum_binary(const int32_t *arr, int len, FILE *fh){
 /* 
   JK, digibase init-sequence TODO: "clean" the init process
 */
-int dbase_init(libusb_device_handle *dev){
+int dbase_init(libusb_device_handle *dev, const char *filename){
   int err, written;
   unsigned char buf0[4] = {[0] = START, [2] = 0x02};/*JK, digiBaseRH start msgs are 4 bytes*/
 
@@ -591,7 +591,7 @@ int dbase_init(libusb_device_handle *dev){
   if( err == 4 ) { /*JK*/
     if(_DEBUG > 0)
       printf("Device uninitialized - Starting dbase_init2():\n");
-    return dbase_init2(dev);
+    return dbase_init2(dev, filename);
   }
 
   /* Already awake - init done */
@@ -607,7 +607,7 @@ int dbase_init(libusb_device_handle *dev){
 /* 
    New Connection - send firmware packages
 */
-int dbase_init2(libusb_device_handle *dev){
+int dbase_init2(libusb_device_handle *dev, const char *filename){
   int k, err, written;
   unsigned char buf0[4] = {[0] = START2, [2] = 2};  /* JK, start_msg buffer */
   
@@ -623,25 +623,13 @@ int dbase_init2(libusb_device_handle *dev){
     err_str("dbase_init2(), when writing START2 command", err);
     return -1;
   }
-  
-  /* Get filename: 
-     defined though gcc compiler option (-DPACK_PATH ...)
-     in Makefile
-  */
-#ifndef PACK_PATH
-    /* if no path is given, assume firmware in . */
-    char str[] = "digiBaseRH.rbf"; /*JK*/ 
-#else
-    char str[strlen(PACK_PATH) + 32];
-    snprintf(str, sizeof(str), "%s/digiBaseRH.rbf", PACK_PATH); /*JK*/ 
-#endif
 
   /* Write packs 1,2 */ /*JK, digiBaseRH - 2 packs of firmware*/
   for(k = 0; k < 2; k++){
  
     /* Get binary data from file */
     int len;
-    unsigned char *buf = dbase_get_firmware_pack(str, k, &len);
+    unsigned char *buf = dbase_get_firmware_pack(filename, k, &len);
     if(buf == NULL){
       fprintf(stderr, "E: unable to read firmware - aborting\n");
       return -EIO;

--- a/src/libdbaserhi.h
+++ b/src/libdbaserhi.h
@@ -254,7 +254,7 @@ extern "C" {
      - if not, continue with dbase_init2()
      - if yes, continue with dbase_init3()
   */
-  int dbase_init(libusb_device_handle *dev);
+  int dbase_init(libusb_device_handle *dev, const char *filename);
 
   /* 
      JK 
@@ -263,7 +263,7 @@ extern "C" {
      - clear/reset counters and spectrum
      - read first status message
    */
-  int dbase_init2(libusb_device_handle *dev);
+  int dbase_init2(libusb_device_handle *dev, const char *filename);
 
   /* 
      JK 


### PR DESCRIPTION
Having a filename hardcoded is not optimal in many situations. This will move the hard-coding of the path name to the top-level (`dbaserh.c`) and keeps it flexible in the library.

I also removed the check of `time[0]>0` in `libdbase_read_lm_packets` which I don't understand why it is there and definitely caused some issue with my system. Furthermore, there are two more checks for `det ` being properly defined.

Great work on putting this library together.